### PR TITLE
Fix portal-parent-fader divs overlaying content

### DIFF
--- a/_sass/_portal.scss
+++ b/_sass/_portal.scss
@@ -76,6 +76,7 @@ iframe{
 			height: 36px;
 			// background-image: linear-gradient(rgba(255,255,255,1), rgba(255,255,255,0));
 			z-index: 50;
+			pointer-events: none;
 		}
 		.portal-parent-fader-bottom{
 			position: absolute;
@@ -85,6 +86,7 @@ iframe{
 			height: 36px;
 			// background-image: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 			z-index: 50;
+			pointer-events: none;
 		}			
 		.portal-parent-text{
 			padding:$base-line-height / 2;


### PR DESCRIPTION
The divs with the classes "portal-parent-fader-top" and "portal-parent-fader-bottom" can be on top of content and prevent interaction like selecting text or clicking on links (see image below). This is fixed by preventing the pointer to interact with them.

As far as I can see, these divs do not have their original purpose of providing a gradient in this theme at all, so it might be a possibility to just remove them completely.

![image](https://user-images.githubusercontent.com/8720147/116308202-86ed2e80-a7a7-11eb-8c44-7f5b8e3586c3.png)
(from the "[Getting started](https://wiki.dendron.so/#getting-started)" section of wiki.dendron.so)